### PR TITLE
Introduce the `Figure` identifier to add captions to images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,13 @@
 
 ## Version 0.0.8
 
+* Introduce the `Figure` identifier to allow the same kind of syntax for images and tables.
+  This also allows adding custom attributes to the figure element.
+* Allow customizing the Markdown identifier for a caption through `markdown_identifier`.
 * Add missing `from __future__ import annotations` to allow type annotations in Python 3.8
+
+### Breaking Changes
+
+* Rename `identifier` in the individual config options to `default_id`. This change was necessary 
+  because it caused a lot of confusion since the identifier term is used by this plugin 
+  to refer to `Table`, `Figure` and `Custom` **identifier**.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,29 @@ take a look at [](#_figure-1).
 take a look at <a href="#_figure-1">figure 1</a>.
 ```
 
+### Customizing The Figure Element
+
+MKDocs allows customizing the image element by adding attributes to the image tag.
+This is done by adding a curly bracket after the image tag and specifying the attributes
+inside the curly brackets. To apply the same kind of customization to the figure element
+the plugin allows adding attributes to the figure element. To maintain compatibility
+with the general Markdown syntax, one needs to use a separate line for the figure
+caption.
+
+```
+Figure: figure caption {class="my-class"}
+
+![](img.jpg)
+```
+
+This will result in 
+
+```html
+<figure id="_figure-1" class="my-class">
+  <img src="img.jpg" />
+  <figcaption>Figure 1. figure caption</figcaption>
+```
+
 ## Tables
 
 The plugin allows easy captioning of tables in markdown. Since Markdown does not
@@ -238,29 +261,44 @@ plugins:
       start_index: 1
       increment_index: 1
       position: bottom  # (top, bottom)
-      identifier: '_table-{index}'
-      reference_text: 'table {index}'
+      default_id: '_table-{index}'
+      reference_text: 'Table {index}'
       caption_prefix: 'Table {index}:'
+      markdown_identifier: 'Table:'
     figure:
       enable: true
       start_index: 1
       increment_index: 1
       position: bottom
-      identifier: '_figure-{index}'
-      reference_text: 'figure {index}'
-      caption_prefix: 'figure {index}:'
+      default_id: '_figure-{index}'
+      reference_text: 'Figure {index}'
+      caption_prefix: 'Figure {index}:'
+      markdown_identifier: 'Figure:'
     custom:
       enable: true
       start_index: 1
       increment_index: 1
       position: bottom
-      identifier: '_{identifier}-{index}'
-      reference_text: '{identifier} {index}'
-      caption_prefix: '{identifier} {index}:'
+      default_id: '_{identifier}-{index}'
+      reference_text: '{Identifier} {index}'
+      caption_prefix: '{Identifier} {index}:'
+      markdown_identifier: '{Identifier}:'
 ```
 
 The `{index}` placeholders are replaced with the current index. The `{identifier}` placeholder
-is replaced with the identifier of the current element and is only relevant for the custom option.  
+is replaced with the lower case identifier and the `{Identifier}` is replaced with the 
+capitalized identifier.
+
+| Option | Description |
+| --- | --- |
+| enable | Enable/disable the captioning/plugin for the specified identifier |
+| start_index | The index to start with |
+| increment_index | The increment for the index |
+| position | The position of the caption (top, bottom) relative to the target element |
+| default_id | The default id assigned to the resulting HTML element |
+| reference_text | The text used for references to this element. Note, this only will be applied if the anchor does not specify its own link text |
+| caption_prefix | The prefix put before of the caption text |
+| markdown_identifier | The identifier that this plugin will search for in the markdown. (Note that every match of this identifier will be treated as a caption element. A false match will most likely result in an error) |
 
 It is also possible to overwrite the default configuration for a specific page. This can be
 done by adding a `caption` section to the page header.

--- a/src/mkdocs_caption/config.py
+++ b/src/mkdocs_caption/config.py
@@ -13,8 +13,8 @@ class IdentifierCaption(base.Config):
         enable: Whether to enable the identifier.
         start_index: The start index (displayed value) for the identifier.
         increment_index: The increment value for the identifier.
-        position: The position of the identifier relative to the caption.
-        identifier: The identifier to use for the caption.
+        position: The position of the caption relative to the element.
+        default_id: The  to use for the caption.
         reference_text: The text to use for the reference (if empty).
         caption_prefix: The prefix to use for the caption.
     """
@@ -23,9 +23,79 @@ class IdentifierCaption(base.Config):
     start_index = config_options.Type(int, default=1)
     increment_index = config_options.Type(int, default=1)
     position = config_options.Choice(("top", "bottom"), default="bottom")
-    identifier = config_options.Type(str, default="_{identifier}-{index}")
-    reference_text = config_options.Type(str, default="{identifier} {index}")
-    caption_prefix = config_options.Type(str, default="{identifier} {index}:")
+    default_id = config_options.Type(str, default="_{identifier}-{index}")
+    reference_text = config_options.Type(str, default="{Identifier} {index}")
+    caption_prefix = config_options.Type(str, default="{Identifier} {index}:")
+    markdown_identifier = config_options.Type(str, default="{Identifier}:")
+
+    @staticmethod
+    def _format_string(
+        input_str: str,
+        identifier: str,
+        index: int | None = None,
+    ) -> str:
+        """Format a string with the given identifier and index.
+
+        Args:
+            input_str: The input string to format.
+            identifier: The identifier to use.
+            index: The index to use.
+
+        Returns:
+            The formatted string.
+        """
+        return input_str.format(
+            Identifier=identifier.capitalize(),
+            identifier=identifier.lower(),
+            index=index,
+        )
+
+    def get_markdown_identifier(self, identifier: str) -> str:
+        """Get the markdown identifier for the given identifier.
+
+        Args:
+            identifier: The identifier to use.
+
+        Returns:
+            The formatted markdown identifier.
+        """
+        return self._format_string(self.markdown_identifier, identifier)
+
+    def get_caption_prefix(self, identifier: str, index: int) -> str:
+        """Get the caption prefix for the given identifier and index.
+
+        Args:
+            identifier: The identifier to use.
+            index: The index to use.
+
+        Returns:
+            The formatted caption prefix.
+        """
+        return self._format_string(self.caption_prefix, identifier, index=index)
+
+    def get_reference_text(self, identifier: str, index: int) -> str:
+        """Get the reference text for the given identifier and index.
+
+        Args:
+            identifier: The identifier to use.
+            index: The index to use.
+
+        Returns:
+            The formatted reference text.
+        """
+        return self._format_string(self.reference_text, identifier, index=index)
+
+    def get_default_id(self, identifier: str, index: int) -> str:
+        """Get the default id for the given identifier and index.
+
+        Args:
+            identifier: The identifier to use.
+            index: The index to use.
+
+        Returns:
+            The formatted default id.
+        """
+        return self._format_string(self.default_id, identifier, index=index)
 
 
 class CaptionConfig(base.Config):

--- a/src/mkdocs_caption/image.py
+++ b/src/mkdocs_caption/image.py
@@ -1,16 +1,44 @@
 """Handle image related captioning."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from lxml import etree
 
-from mkdocs_caption.config import IdentifierCaption
-from mkdocs_caption.helper import TreeElement, update_references
-from mkdocs_caption.logger import PluginLogger
+from mkdocs_caption.helper import TreeElement, update_references, wrap_md_captions
+
+if TYPE_CHECKING:
+    from mkdocs_caption.config import IdentifierCaption
+    from mkdocs_caption.logger import PluginLogger
+
+IMG_CAPTION_TAG = "figure-caption"
+
+
+def preprocess_markdown(markdown: str, *, config: IdentifierCaption) -> str:
+    """Preprocess markdown to wrap image captions.
+
+    The image captions are wrapped in a custom html
+    tag to make them easier to find later.
+
+    Args:
+        markdown: markdown string
+        config: plugin configuration for images
+
+    Returns:
+        markdown string with custom captions wrapped
+    """
+    if not config.enable:
+        return markdown
+    identifier = config.get_markdown_identifier("figure")
+    return wrap_md_captions(markdown, identifier=identifier, html_tag=IMG_CAPTION_TAG)
 
 
 def wrap_image(
+    *,
     img: TreeElement,
-    custom_id: str,
     caption: TreeElement,
     position: str,
+    figure_attrib: dict[str, str],
 ) -> None:
     """Wrap an image element in a figure element with a custom caption.
 
@@ -20,16 +48,16 @@ def wrap_image(
 
     Args:
         img: The image element to wrap.
-        custom_id: The identifier of the custom caption.
         caption: The caption element to use.
         position: The position of the caption relative to the image. (top, bottom)
+        figure_attrib: Additional attributes for the figure element.
     """
     target = img
     parent = img.getparent()
     if parent is not None and parent.tag == "a":
         target = parent
     figure_element = etree.Element("figure", None, None)
-    figure_element.attrib["id"] = custom_id
+    figure_element.attrib.update(figure_attrib)
     target.addnext(figure_element)
     if position == "top":
         figure_element.append(caption)
@@ -39,7 +67,72 @@ def wrap_image(
         figure_element.append(caption)
 
 
+def postprocess_image(
+    *,
+    img_element: TreeElement,
+    title: str,
+    tree: TreeElement,
+    config: IdentifierCaption,
+    logger: PluginLogger,
+    index: int,
+    figure_attrib: dict[str, str] | None,
+) -> None:
+    """Postprocess an image element to handle custom image captions.
+
+    This function takes an image element and postprocesses it to handle custom
+    image captions. If the image has a title attribute, it wraps the image in a
+    figure element with a custom caption.
+
+    Args:
+        img_element: The image element to postprocess.
+        title: The title of the image.
+        tree: The root element of the XML tree.
+        config: The plugin configuration.
+        logger: Current plugin logger.
+        index: The index of the image element.
+        figure_attrib: Additional attributes for the figure element.
+    """
+    # Its a bit of a tricky situation here. The used can specify a custom id
+    # both on the figure element and the image element. The references to both
+    # of these elements needs to be updated.
+    if "id" in img_element.attrib:
+        update_references(
+            tree,
+            img_element.attrib["id"],
+            config.get_reference_text(index=index, identifier="figure"),
+        )
+    if not figure_attrib:
+        figure_attrib = {}
+    if "id" not in figure_attrib:
+        figure_attrib["id"] = config.get_default_id(index=index, identifier="figure")
+    update_references(
+        tree,
+        figure_attrib["id"],
+        config.get_reference_text(index=index, identifier="figure"),
+    )
+    # assemble the caption element
+    caption_prefix = config.get_caption_prefix(
+        index=index,
+        identifier="figure",
+    )
+    try:
+        caption_element = etree.fromstring(
+            f"<figcaption>{caption_prefix} {title}</figcaption>",
+        )
+    except etree.XMLSyntaxError:
+        logger.error("Invalid XML in caption: %s", title)
+        return
+    # wrap the image in figure with the caption element
+    wrap_image(
+        img=img_element,
+        caption=caption_element,
+        position=config.position,
+        figure_attrib=figure_attrib,
+    )
+
+
 def postprocess_html(
+    *,
     tree: TreeElement,
     config: IdentifierCaption,
     logger: PluginLogger,
@@ -58,29 +151,38 @@ def postprocess_html(
     """
     if not config.enable:
         return
+
+    # Handle additional figure caption elements
+    custom_figure_attrib = {}
+    for custom_caption in tree.xpath(f"//{IMG_CAPTION_TAG}"):
+        # unused attribute identifier
+        custom_caption.attrib.pop("identifier")
+        a_wrapper = custom_caption.getparent()
+        try:
+            target_element = a_wrapper.getnext().xpath("//img")[0]
+        except IndexError:
+            logger.error(
+                "Figure caption must be followed by a img element. Skipping: %s",
+                custom_caption.text,
+            )
+            continue
+        target_element.attrib["title"] = custom_caption.text
+        custom_figure_attrib[target_element] = custom_caption.attrib
+    # Iterate through all images and wrap them in a figure element if requested
     index = config.start_index
     for img_element in tree.xpath("//p/a/img|//p/img"):
-        title = img_element.get("title", img_element.get("alt", None))
-        custom_id = img_element.get(
-            "id",
-            config.identifier.format(index=index, identifier="figure"),
+        figure_attrib = custom_figure_attrib.get(img_element, {})
+        # We pop the title here so its not duplicated in the img element
+        title = img_element.attrib.pop("title", img_element.get("alt", None))
+        if not title:
+            continue
+        postprocess_image(
+            img_element=img_element,
+            title=title,
+            tree=tree,
+            config=config,
+            logger=logger,
+            index=index,
+            figure_attrib=figure_attrib,
         )
-        update_references(
-            tree,
-            custom_id,
-            config.reference_text.format(index=index, identifier="Figure"),
-        )
-        if title:
-            caption_prefix = config.caption_prefix.format(
-                index=index,
-                identifier="Figure",
-            )
-            try:
-                caption_element = etree.fromstring(
-                    f"<figcaption>{caption_prefix} {title}</figcaption>",
-                )
-            except etree.XMLSyntaxError:
-                logger.error("Invalid XML in caption: %s", title)
-                continue
-            wrap_image(img_element, custom_id, caption_element, config.position)
-            index += config.increment_index
+        index += config.increment_index


### PR DESCRIPTION
Allow a custom markdown identifier for all types.

This PR adds a config parameter markdown_identifier which
allows changing the identifier this plugin looks for when parsing
a markdown file.

Since the images did not support this kind of syntax it was
introduces as well.

```
Figure: Captions {<figure properties>}

![](img.jpg)
```

This change was necessary to allow adding attributes to the
figure element directly. Previously this was only possible
for the img elements directly.

Fixes #1 