### PR TITLE
Introduce option to ignore specific classes during the conversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 0.0.11
 
+* Prevent conversion of emojis into figure elements with captions.
+* Add new config parameter `ignore_classes` to explicitly prevent conversion 
+  of specific images into figures.
+
+## Version 0.0.11
+
 * Prevent conversion of inline images even if they have an alt text (#9)
 
 ## Version 0.0.10

--- a/demo/docs/index.md
+++ b/demo/docs/index.md
@@ -25,7 +25,7 @@ and it goes on for multiple lines
 
     ![](assets/demo.png){width="200"}
 
-Inline images should not be converted ![Hello](assets/demo.png){width="30"}, even if they have a alt text.
+Inline images should not be converted ![Hello](assets/demo.png){width="30"}, even if they have a alt text. :smile:
 
 ## Tables
 

--- a/demo/mkdocs.yml
+++ b/demo/mkdocs.yml
@@ -8,7 +8,10 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
-
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 plugins:
   caption:
     additional_identifier: ["List", "Code"]

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,6 +30,7 @@ plugins:
       markdown_identifier: 'Figure:'
       allow_indented_caption: True
       ignore_alt: False
+      ignore_classes: ["twemoji"]
     custom: # (4)!
       enable: true
       start_index: 1
@@ -74,7 +75,8 @@ The following table lists all available options.
 | markdown_identifier | The identifier that this plugin will search for in the markdown. (Note that every match of this identifier will be treated as a caption element. A false match will most likely result in an error) |
 | allow_indented_caption | Flag if caption elements should also be parsed within indented blocks. By default this is enabled. |
 | ignore_alt | Flag if the alt attribute should be ignored. This will disable the feature that 
-uses the alt text as a caption. (Only available for figures)|
+uses the alt text as a caption. (Only available for figures) |
+| ignore_classes | List of classes ignored when adding the captions. (Only available for figures) |
 
 ## Overwriting the default configuration
 

--- a/src/mkdocs_caption/config.py
+++ b/src/mkdocs_caption/config.py
@@ -111,6 +111,10 @@ class FigureCaption(IdentifierCaption):
     """
 
     ignore_alt = config_options.Type(bool, default=False)
+    ignore_classes = config_options.ListOfItems(
+        config_options.Type(str),
+        default=["twemoji"],
+    )
 
 
 class CaptionConfig(base.Config):

--- a/src/mkdocs_caption/image.py
+++ b/src/mkdocs_caption/image.py
@@ -184,6 +184,8 @@ def postprocess_html(
     index = config.start_index
     for img_element in tree.xpath("//p/a/img|//p/img"):
         figure_attrib = custom_figure_attrib.get(img_element, {})
+        if img_element.attrib.get("class", None) in config.ignore_classes:
+            continue
         # We pop the title here so its not duplicated in the img element
         title = img_element.attrib.pop("title", None)
         if title is None:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -489,3 +489,33 @@ def test_figure_caption_ignores_alt_if_disabled():
     result = result[len("<html><body>") : -len("</body></html>")]
     result = result[len("<p>") : -len("</p>")]
     assert result == img
+
+
+def test_figure_caption_uses_unmarked_classes():
+    config = FigureCaption()
+    img = '<img class="custom_class" src="test.png" title="=text" id="test_id">'
+    html = p(img)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
+    logger = get_logger("test.md")
+    image.postprocess_html(tree=tree, config=config, logger=logger)
+    result = etree.tostring(tree, encoding="unicode", method="html")
+    # htmlparser adds <html><body> tags, remove them
+    result = result[len("<html><body>") : -len("</body></html>")]
+    result = result[len("<p>") : -len("</p>")]
+    assert "figcaption" in result
+
+
+def test_figure_caption_ignores_marked_classes():
+    config = FigureCaption()
+    img = '<img class="twemoji" src="test.png" title="=text" id="test_id">'
+    html = p(img)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
+    logger = get_logger("test.md")
+    image.postprocess_html(tree=tree, config=config, logger=logger)
+    result = etree.tostring(tree, encoding="unicode", method="html")
+    # htmlparser adds <html><body> tags, remove them
+    result = result[len("<html><body>") : -len("</body></html>")]
+    result = result[len("<p>") : -len("</p>")]
+    assert result == img


### PR DESCRIPTION
This commit adds a new config element `ignore_classes` to explicitly prevent certain classes from beeing converted.

This option was added to ignore things like emojis when creating the figures.