### PR TITLE
Allow markdown syntax within captions (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.0.1
+
+* Allow markdown syntax within the caption element.
+
 ## Version 1.0.0
 
 * Prevent conversion of emojis into figure elements with captions.

--- a/demo/docs/index.md
+++ b/demo/docs/index.md
@@ -29,7 +29,7 @@ Inline images should not be converted ![Hello](assets/demo.png){width="30"}, eve
 
 ## Tables
 
-Table: Table caption
+Table: Table **bold** caption
 
 | My | Table |
 | - | - |

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -17,6 +17,10 @@ With the plugin enabled, one can now use an easy and descriptive syntax to add
 captions to figures and tables. The captions are automatically numbered and
 can be referenced in the text.
 
+!!! tip
+
+    The caption text is converted by mkdocs itself. This means that technically
+    a caption can contain the same things than any other text.
 
 === "Markdown"
 

--- a/src/mkdocs_caption/config.py
+++ b/src/mkdocs_caption/config.py
@@ -1,4 +1,5 @@
 """The configuration options for the Caption plugin."""
+
 from __future__ import annotations
 
 import typing as t

--- a/src/mkdocs_caption/logger.py
+++ b/src/mkdocs_caption/logger.py
@@ -1,4 +1,5 @@
 """Setup custom logger that is mkdocs compatible."""
+
 from __future__ import annotations
 
 import logging

--- a/src/mkdocs_caption/plugin.py
+++ b/src/mkdocs_caption/plugin.py
@@ -1,4 +1,5 @@
 """MkDocs plugin for custom image and table captions."""
+
 from lxml import etree
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import BasePlugin, event_priority

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,5 @@
 """Test the plugin with a MkDocs demo site."""
+
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,4 +1,5 @@
 """Tests for the image module."""
+
 from lxml import etree
 
 from mkdocs_caption import table
@@ -52,7 +53,9 @@ Table: My Caption
 hjkhjk
     """
     result = table.preprocess_markdown(markdown, config=config)
-    assert '<table-caption identifier="Table">My Caption</table-caption>' in result
+    assert '<table-caption identifier="Table">' in result
+    assert "My Caption" in result
+    assert "<table-caption-end>" in result
 
 
 def test_preprocess_options_ok():
@@ -83,7 +86,9 @@ Custom& My Caption
 hjkhjk
     """
     result = table.preprocess_markdown(markdown, config=config)
-    assert '<table-caption identifier="Custom&">My Caption</table-caption>' in result
+    assert '<table-caption identifier="Custom&">' in result
+    assert "My Caption" in result
+    assert "<table-caption-end>" in result
 
 
 def test_preprocess_custom_ignores_default_identifier():
@@ -114,8 +119,13 @@ Table: My Caption
 hjkhjk
     """
     result = table.preprocess_markdown(markdown, config=config)
-    assert '<table-caption identifier="Table">My Caption</table-caption>' in result
-    assert '<table-caption identifier="Table">First</table-caption>' in result
+    assert (
+        '<table-caption identifier="Table">\n\nFirst\n\n<table-caption-end>' in result
+    )
+    assert (
+        '<table-caption identifier="Table">\n\nMy Caption\n\n<table-caption-end>'
+        in result
+    )
 
 
 def div(*args):
@@ -126,37 +136,49 @@ def a(*args):
     return f'<a>{"".join(args)}</a>'
 
 
-DEFAULT_TABLE = str(
+def p(*args):
+    return f'<p>{"".join(args)}</p>'
+
+
+DEFAULT_TABLE = (
     '<table><thead><tr><th colspan="2">logo</th></tr></thead><tbody><tr>'
-    '<td colspan="2">type</td></tr><tr><td>html</td><td>pdf</td></tr></tbody></table>',
+    '<td colspan="2">type</td></tr><tr><td>html</td><td>pdf</td></tr></tbody></table>'
 )
 
-DEFAULT_TABLE_CAPTION = '<table-caption identifier="Table">My Caption</table-caption>'
+DEFAULT_TABLE_CAPTION = (
+    '<p><table-caption identifier="Table"></p>'
+    "<p>My Caption</p><p><table-caption-end></p>"
+)
 
 
 def test_postprocess_disabled():
     config = IdentifierCaption()
     config.enable = False
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
-    assert result == html
+    assert DEFAULT_TABLE in result
 
 
 def test_postprocess_no_identifier():
     config = IdentifierCaption()
     html = div(a("caption"), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
+    # HTMLParser adds <html><body> tags, remove them
+    result = result[len("<html><body>") : -len("</body></html>")]
     assert result == html
 
 
 def test_postprocess_default_identifier():
     config = IdentifierCaption()
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert (
@@ -164,12 +186,36 @@ def test_postprocess_default_identifier():
     )
 
 
+def test_postprocess_multiline_caption():
+    config = IdentifierCaption()
+    caption = (
+        '<p><table-caption identifier="Table"></p>'
+        "<p>My Caption</p><p>Part2</p><p><table-caption-end></p>"
+    )
+    html = div(caption, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
+    table.postprocess_html(tree=tree, config=config, logger=None)
+    result = etree.tostring(tree, encoding="unicode", method="html")
+    assert (
+        '<caption style="caption-side:bottom">Table 1: <p>My Caption</p>'
+        "<p>Part2</p></caption>"
+    ) in result
+
+
 def test_postprocess_multiple():
     config = IdentifierCaption()
-    caption1 = '<table-caption identifier="Table">First</table-caption>'
-    caption2 = '<table-caption identifier="Table">Second</table-caption>'
-    html = div(div(a(caption1), DEFAULT_TABLE), div(a(caption2), DEFAULT_TABLE))
-    tree = etree.fromstring(html)
+    caption1 = (
+        '<p><table-caption identifier="Table"></p>'
+        "<p>First</p><p><table-caption-end></p>"
+    )
+    caption2 = (
+        '<p><table-caption identifier="Table"></p>'
+        "<p>Second</p><p><table-caption-end></p>"
+    )
+    html = div(div(caption1, DEFAULT_TABLE), div(caption2, DEFAULT_TABLE))
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert '<caption style="caption-side:bottom">Table 1: First</caption>' in result
@@ -179,8 +225,9 @@ def test_postprocess_multiple():
 def test_postprocess_custom_start_index():
     config = IdentifierCaption()
     config.start_index = 10
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert (
@@ -191,10 +238,17 @@ def test_postprocess_custom_start_index():
 def test_postprocess_custom_increment():
     config = IdentifierCaption()
     config.increment_index = 10
-    caption1 = '<table-caption identifier="Table">First</table-caption>'
-    caption2 = '<table-caption identifier="Table">Second</table-caption>'
-    html = div(div(a(caption1), DEFAULT_TABLE), div(a(caption2), DEFAULT_TABLE))
-    tree = etree.fromstring(html)
+    caption1 = (
+        '<p><table-caption identifier="Table"></p>'
+        "<p>First</p><p><table-caption-end></p>"
+    )
+    caption2 = (
+        '<p><table-caption identifier="Table"></p>'
+        "<p>Second</p><p><table-caption-end></p>"
+    )
+    html = div(div(caption1, DEFAULT_TABLE), div(caption2, DEFAULT_TABLE))
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert '<caption style="caption-side:bottom">Table 1: First</caption>' in result
@@ -204,14 +258,16 @@ def test_postprocess_custom_increment():
 def test_postprocess_position():
     config = IdentifierCaption()
     config.position = "top"
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert '<caption style="caption-side:top">Table 1: My Caption</caption>' in result
 
     config.position = "bottom"
-    tree = etree.fromstring(html)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert (
@@ -221,8 +277,9 @@ def test_postprocess_position():
 
 def test_postprocess_default_id():
     config = IdentifierCaption()
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert 'id="_table-1"' in result
@@ -231,14 +288,16 @@ def test_postprocess_default_id():
 def test_postprocess_custom_id():
     config = IdentifierCaption()
     config.default_id = "custom-{identifier}-{index}"
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert 'id="custom-table-1"' in result
 
     config.default_id = "test-{index}"
-    tree = etree.fromstring(html)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert 'id="test-1"' in result
@@ -247,8 +306,9 @@ def test_postprocess_custom_id():
 def test_postprocess_custom_caption_prefix():
     config = IdentifierCaption()
     config.caption_prefix = "custom {identifier} {index}:"
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert (
@@ -260,8 +320,9 @@ def test_postprocess_custom_caption_prefix():
 def test_postprocess_default_reference():
     config = IdentifierCaption()
     reference_element = '<a href="#_table-1"></a>'
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE, div(reference_element))
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE, div(reference_element))
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert '<a href="#_table-1">Table 1</a>' in result
@@ -270,8 +331,9 @@ def test_postprocess_default_reference():
 def test_postprocess_ignore_reference_with_text():
     config = IdentifierCaption()
     reference_element = '<a href="#_table-1">Test</a>'
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE, div(reference_element))
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE, div(reference_element))
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert '<a href="#_table-1">Test</a>' in result
@@ -281,8 +343,9 @@ def test_postprocess_custom_reference():
     config = IdentifierCaption()
     config.reference_text = "custom {identifier} {index}"
     reference_element = '<a href="#_table-1"></a>'
-    html = div(a(DEFAULT_TABLE_CAPTION), DEFAULT_TABLE, div(reference_element))
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE, div(reference_element))
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert '<a href="#_table-1">custom table 1</a>' in result
@@ -290,9 +353,13 @@ def test_postprocess_custom_reference():
 
 def test_colgroups():
     config = IdentifierCaption()
-    caption = '<table-caption identifier="Table" cols="1,3">My Caption</table-caption>'
-    html = div(a(caption), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    caption = (
+        '<p><table-caption identifier="Table" cols="1,3"></p>'
+        "<p>My Caption</p><p><table-caption-end></p>"
+    )
+    html = div(caption, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert (
@@ -304,44 +371,45 @@ def test_colgroups():
 def test_colgroups_alsways_100_percent():
     config = IdentifierCaption()
     caption = (
-        '<table-caption identifier="Table" cols="456,85">My Caption</table-caption>'
+        '<p><table-caption identifier="Table" cols="456,85"></p>'
+        "<p>My Caption</p><p><table-caption-end></p>"
     )
-    html = div(a(caption), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(caption, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     table.postprocess_html(tree=tree, config=config, logger=None)
     result = etree.tostring(tree, encoding="unicode", method="html")
     assert (
-        str(
-            '<colgroup><col span="1" width="84.28835489833642%">'
-            '<col span="1" width="15.711645101663585%"></colgroup>',
-        )
-        in result
-    )
+        '<colgroup><col span="1" width="84.28835489833642%">'
+        '<col span="1" width="15.711645101663585%"></colgroup>'
+    ) in result
 
 
 def test_table_caption_without_table(caplog):
     config = IdentifierCaption()
-    html = div(a(DEFAULT_TABLE_CAPTION), a("I am a table"))
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, a("I am a table"))
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     logger = get_logger("test.md")
     with caplog.at_level("ERROR"):
         table.postprocess_html(tree=tree, config=config, logger=logger)
     assert "ERROR" in caplog.text
     result = etree.tostring(tree, encoding="unicode", method="html")
-    assert result == html
+    assert "<a>I am a table</a>" in result
 
 
 def test_table_caption_with_xml(caplog):
     config = IdentifierCaption()
     config.caption_prefix = "<not nice> {index}:"
 
-    caption = '<table-caption identifier="Table">My Caption</table-caption>'
-
-    html = div(a(caption), DEFAULT_TABLE)
-    tree = etree.fromstring(html)
+    html = div(DEFAULT_TABLE_CAPTION, DEFAULT_TABLE)
+    parser = etree.HTMLParser()
+    tree = etree.fromstring(html, parser)
     logger = get_logger("test.md")
     with caplog.at_level("ERROR"):
         table.postprocess_html(tree=tree, config=config, logger=logger)
     assert "ERROR" in caplog.text
     result = etree.tostring(tree, encoding="unicode", method="html")
+    # HTMLParser adds <html><body> tags, remove them
+    result = result[len("<html><body>") : -len("</body></html>")]
     assert result == div(DEFAULT_TABLE)


### PR DESCRIPTION
This commit changes the logic of the preprocessing that wraps the table caption such that the caption is self is still plain markdown. This causes the mkdocs parser to convert the caption into html by its own, which allows the usage of markown in captions.

The logic is adapted in such a way that a custom html element is created both befor and after the caption. The caption itself is untouched. In the post processing the two added tags can be used to find the start and end of the caption easily.