### PR TITLE
Fix Bug that caused wrong text references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 1.2.1
+
+* Fix bug in the post processing which cause references with ids which contain other ids
+  to be replaced with the wrong text.
+
 ## Version 1.2.0
 
 * Allow automatic link text generation across different pages.

--- a/src/mkdocs_caption/post_processor.py
+++ b/src/mkdocs_caption/post_processor.py
@@ -36,9 +36,9 @@ class PostProcessor:
             "{page_title}",
             page.title,
         ).replace("{local_ref}", text)
-        self._regex_to_apply[rf"{page.file.src_path[:-3]}/#{identifier}"] = (
+        self._regex_to_apply[rf'{page.file.src_path[:-3]}/#{identifier}"'] = (
             re.compile(
-                rf"({page.file.src_path[:-3]}/#{identifier}.*?>)(</a>)",
+                rf'({page.file.src_path[:-3]}/#{identifier}".*?>)(</a>)',
                 flags=re.MULTILINE | re.DOTALL,
             ),
             rf"\1{target_text}\2",
@@ -48,7 +48,7 @@ class PostProcessor:
         self._local_regex[page.file.src_uri].append(
             (
                 re.compile(
-                    rf"(\"#{identifier}.*?>)(</a>)",
+                    rf'("#{identifier}".*?>)(</a>)',
                     flags=re.MULTILINE | re.DOTALL,
                 ),
                 rf"\1{text}\2",

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -462,7 +462,7 @@ def test_postprocess_default_reference(dummy_page):
         page=page,
         post_processor=post_processor,
     )
-    assert "test/#_list-1" in post_processor.regex_to_apply
+    assert 'test/#_list-1"' in post_processor.regex_to_apply
 
 
 def test_postprocess_ignore_reference_with_text(dummy_page):
@@ -499,7 +499,7 @@ def test_postprocess_custom_reference(dummy_page):
         page=page,
         post_processor=post_processor,
     )
-    assert "test/#_list-1" in post_processor.regex_to_apply
+    assert 'test/#_list-1"' in post_processor.regex_to_apply
 
 
 def test_custom_caption_no_target(caplog, dummy_page):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -520,7 +520,7 @@ def test_postprocess_default_reference(dummy_page):
         page=dummy_page,
         post_processor=post_processor,
     )
-    assert "test/#_figure-1" in post_processor.regex_to_apply
+    assert 'test/#_figure-1"' in post_processor.regex_to_apply
 
 
 def test_postprocess_ignore_reference_with_text(dummy_page):
@@ -557,7 +557,7 @@ def test_postprocess_custom_reference(dummy_page):
         page=dummy_page,
         post_processor=post_processor,
     )
-    assert "test/#_figure-1" in post_processor.regex_to_apply
+    assert 'test/#_figure-1"' in post_processor.regex_to_apply
 
 
 def test_figure_caption_with_no_img(caplog, dummy_page):

--- a/tests/test_post_processor.py
+++ b/tests/test_post_processor.py
@@ -6,7 +6,7 @@ from mkdocs_caption.post_processor import PostProcessor
 def test_post_processor_register(dummy_page):
     post_processor = PostProcessor()
     post_processor.register_target("identifier", "text", dummy_page)
-    assert "test/#identifier" in post_processor.regex_to_apply
+    assert 'test/#identifier"' in post_processor.regex_to_apply
     assert dummy_page.file.src_uri in post_processor._local_regex  # noqa: SLF001
 
 
@@ -48,4 +48,14 @@ def test_post_processor_replace_existing_text(dummy_page):
     assert (
         post_processor.post_process(dummy_page, content)
         == '<a href="test/#identifier">hello</a>'
+    )
+
+
+def test_post_processor_similar_tag(dummy_page):
+    post_processor = PostProcessor()
+    post_processor.register_target("test", "wrong", dummy_page)
+    post_processor.register_target("test2", "right", dummy_page)
+    content = '<a href="#test2"></a>'
+    assert (
+        post_processor.post_process(dummy_page, content) == '<a href="#test2">right</a>'
     )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -411,7 +411,7 @@ def test_postprocess_default_reference(dummy_page):
         post_processor=post_processor,
     )
 
-    assert "test/#_table-1" in post_processor.regex_to_apply
+    assert 'test/#_table-1"' in post_processor.regex_to_apply
 
 
 def test_postprocess_ignore_reference_with_text(dummy_page):
@@ -447,7 +447,7 @@ def test_postprocess_custom_reference(dummy_page):
         post_processor=post_processor,
     )
 
-    assert "test/#_table-1" in post_processor.regex_to_apply
+    assert 'test/#_table-1"' in post_processor.regex_to_apply
 
 
 def test_colgroups(dummy_page):


### PR DESCRIPTION
This commit fixes a bug in the post-processing that caused IDs containing other IDs to be replaced with the wrong text.

closes #19 