### PR TITLE
Adapt figure generation to work with hash fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## Version 1.2.1
+## Version 1.3.0
 
 * Fix bug in the post processing which cause references with ids which contain other ids
   to be replaced with the wrong text.
+* Adapt figure generation to allow packing multiple images into the same figure.
+  This is necessary to e.g allow having different images for light and dark mode.
 
 ## Version 1.2.0
 

--- a/demo/docs/index.md
+++ b/demo/docs/index.md
@@ -2,6 +2,9 @@
 
 For full documentation, visit [https://tobiasah.github.io/mkdocs-caption/](https://tobiasah.github.io/mkdocs-caption/).
 
+![Image title](https://dummyimage.com/600x400/f5f5f5/aaaaaa#only-light){width=80% #fig-schematic}
+![Image title](https://dummyimage.com/600x400/21222c/d5d7e2#only-dark){width=80% #fig-schematic}
+
 ## Images
 
 ![This uses the alt as caption](assets/demo.png){width="200"}

--- a/demo/mkdocs.yml
+++ b/demo/mkdocs.yml
@@ -2,6 +2,24 @@ site_name: MkDocs Captions Demo
 
 theme:
   name: material
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+   # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 
 markdown_extensions:
   - pymdownx.extra: {}

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ plugins:
       allow_indented_caption: True
       ignore_alt: False
       ignore_classes: ["twemoji"]
+      ignore_hash: False
     custom: # (4)!
       enable: true
       start_index: 1
@@ -78,6 +79,7 @@ The following table lists all available options.
 | ignore_alt | Flag if the alt attribute should be ignored. This will disable the feature that 
 uses the alt text as a caption. (Only available for figures) |
 | ignore_classes | List of classes ignored when adding the captions. (Only available for figures) |
+| ignore_hash | Flag is there is not special parsing of hashes in the image url. This disables the support for packing images into the same figure (e.g light and dark mode) |
 
 ## Overwriting the default configuration
 

--- a/src/mkdocs_caption/config.py
+++ b/src/mkdocs_caption/config.py
@@ -116,6 +116,7 @@ class FigureCaption(IdentifierCaption):
         config_options.Type(str),
         default=["twemoji"],
     )
+    ignore_hash = config_options.Type(bool, default=False)
 
 
 class CaptionConfig(base.Config):


### PR DESCRIPTION
This commit adapts the figure generation to test if an image contains a hash and potentially requires putting multiple images into the same figure.

This allows having different images for light and dark modes in the exact figure.

fixes #23 

